### PR TITLE
Fix crumb for anonymous user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,13 +86,13 @@ task integTest(type: Test, dependsOn: mockTest) {
         events 'started', 'passed', 'failed'
     }
     def authentication = [:]
-    def possibleAuth = project.findProperty('testJenkinsRestCredentials')
+    def possibleAuth = project.findProperty('testJenkinsRestApiToken')
     if (possibleAuth) {
-        authentication['test.jenkins.rest.credentials'] = possibleAuth
+        authentication['test.jenkins.rest.api.token'] = possibleAuth
     } else {
-        possibleAuth = project.findProperty('testJenkinsRestToken')
+        possibleAuth = project.findProperty('testJenkinsRestCredentials')
         if (possibleAuth) {
-            authentication['test.jenkins.rest.token'] = possibleAuth
+            authentication['test.jenkins.rest.credentials'] = possibleAuth
         } else {
             logger.quiet 'No authentication parameters found. Assuming anonymous...'
         }

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
@@ -36,10 +36,10 @@ public class JenkinsAuthentication extends Credentials {
      * Create instance of JenkinsAuthentication
      * 
      * @param authValue value to use for authentication type HTTP header.
-     * @param authType authentication type (e.g. Basic, Bearer, Anonymous).
+     * @param authType authentication type (e.g. UsernamePassword, ApiToken, Anonymous).
      */
     private JenkinsAuthentication(final String authValue, final AuthenticationType authType) {
-        super(null, authType == AuthenticationType.Basic && authValue.contains(":")
+        super(null, (authType == AuthenticationType.UsernamePassword || authType == AuthenticationType.ApiToken) && authValue.contains(":")
                 ? base64().encode(authValue.getBytes())
                 : authValue);
         this.authType = authType;    
@@ -64,26 +64,26 @@ public class JenkinsAuthentication extends Credentials {
         private AuthenticationType authType;
 
         /**
-         * Set 'Basic' credentials.
+         * Set 'UsernamePassword' credentials.
          * 
-         * @param basicCredentials value to use for 'Basic' credentials.
+         * @param usernamePassword value to use for 'UsernamePassword' credentials.
          * @return this Builder.
          */
-        public Builder credentials(final String basicCredentials) {
-            this.authValue = Objects.requireNonNull(basicCredentials);
-            this.authType = AuthenticationType.Basic;
+        public Builder credentials(final String usernamePassword) {
+            this.authValue = Objects.requireNonNull(usernamePassword);
+            this.authType = AuthenticationType.UsernamePassword;
             return this;
         }
 
         /**
-         * Set 'Bearer' credentials.
-         * 
-         * @param tokenCredentials value to use for 'Bearer' credentials.
+         * Set 'ApiToken' credentials.
+         *
+         * @param apiTokenCredentials value to use for 'ApiToken' credentials.
          * @return this Builder.
          */
-        public Builder token(final String tokenCredentials) {
-            this.authValue = Objects.requireNonNull(tokenCredentials);
-            this.authType = AuthenticationType.Bearer;
+        public Builder apiToken(final String apiTokenCredentials) {
+            this.authValue = Objects.requireNonNull(apiTokenCredentials);
+            this.authType = AuthenticationType.ApiToken;
             return this;
         }
 

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsClient.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsClient.java
@@ -168,14 +168,15 @@ public final class JenkinsClient implements Closeable {
         }
 
         /**
-         * Optional token to use for authentication.
+         * Optional Api token to use for authentication.
+         * This is not a Bearer token, hence the name apiToken.
          *
-         * @param token authentication token.
+         * @param apiToken authentication token.
          * @return this Builder.
          */
-        public Builder token(final String token) {
+        public Builder apiToken(final String apiToken) {
             authBuilder = JenkinsAuthentication.builder()
-                    .token(token);
+                    .apiToken(apiToken);
             return this;
         }
 

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
@@ -28,8 +28,8 @@ public class JenkinsConstants {
     public static final String CREDENTIALS_SYSTEM_PROPERTY = "jenkins.rest.credentials";
     public static final String CREDENTIALS_ENVIRONMENT_VARIABLE = CREDENTIALS_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
-    public static final String TOKEN_SYSTEM_PROPERTY = "jenkins.rest.token";
-    public static final String TOKEN_ENVIRONMENT_VARIABLE = TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
+    public static final String API_TOKEN_SYSTEM_PROPERTY = "jenkins.rest.api.token";
+    public static final String API_TOKEN_ENVIRONMENT_VARIABLE = API_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
     public static final String DEFAULT_ENDPOINT = "http://127.0.0.1:7990";
 

--- a/src/main/java/com/cdancy/jenkins/rest/auth/AuthenticationType.java
+++ b/src/main/java/com/cdancy/jenkins/rest/auth/AuthenticationType.java
@@ -22,18 +22,24 @@ package com.cdancy.jenkins.rest.auth;
  */
 public enum AuthenticationType {
 
-    Basic("Basic"),
-    Bearer("Bearer"),
-    Anonymous("");
+    UsernamePassword("UsernamePassword", "Basic"),
+    ApiToken("ApiToken", "Basic"),
+    Anonymous("Anonymous", "");
 
-    private final String type;
+    private final String authName;
+    private final String authScheme;
 
-    private AuthenticationType(final String type) {
-        this.type = type;
+    private AuthenticationType(final String authName, final String authScheme) {
+        this.authName = authName;
+        this.authScheme = authScheme;
+    }
+
+    public String getAuthScheme() {
+        return authScheme;
     }
 
     @Override
     public String toString() {
-        return type;
+        return authName;
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsNoCrumbAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsNoCrumbAuthenticationFilter.java
@@ -43,7 +43,7 @@ public class JenkinsNoCrumbAuthenticationFilter implements HttpRequestFilter {
         if (creds.authType() == AuthenticationType.Anonymous) {
             return request;
         } else {
-            final String authHeader = creds.authType() + " " + creds.authValue();
+            final String authHeader = creds.authType().getAuthScheme() + " " + creds.authValue();
             return request.toBuilder().addHeader(HttpHeaders.AUTHORIZATION, authHeader).build();
         }
     }

--- a/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsMockTest.java
@@ -66,7 +66,7 @@ public class BaseJenkinsMockTest {
      * @return instance of JenkinsApi.
      */
     public JenkinsApi api(final URL url) {
-        final JenkinsAuthentication creds = JenkinsAuthentication.builder().build();
+        final JenkinsAuthentication creds = JenkinsAuthentication.builder().apiToken("user:apiKey").build();
         final JenkinsAuthenticationModule credsModule = new JenkinsAuthenticationModule(creds);
         return ContextBuilder.newBuilder(provider)
                 .endpoint(url.toString())

--- a/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsMockTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 
 import com.cdancy.jenkins.rest.config.JenkinsAuthenticationModule;
 
@@ -70,7 +71,7 @@ public class BaseJenkinsMockTest {
         return ContextBuilder.newBuilder(provider)
                 .endpoint(url.toString())
                 .overrides(setupProperties())
-                .modules(Lists.newArrayList(credsModule))
+                .modules(Lists.newArrayList(credsModule, new SLF4JLoggingModule()))
                 .buildApi(JenkinsApi.class);
     }
 

--- a/src/test/java/com/cdancy/jenkins/rest/TestUtilities.java
+++ b/src/test/java/com/cdancy/jenkins/rest/TestUtilities.java
@@ -43,8 +43,8 @@ public class TestUtilities extends JenkinsUtils {
     public static final String TEST_CREDENTIALS_SYSTEM_PROPERTY = "test.jenkins.rest.credentials";
     public static final String TEST_CREDENTIALS_ENVIRONMENT_VARIABLE = TEST_CREDENTIALS_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
-    public static final String TEST_TOKEN_SYSTEM_PROPERTY = "test.jenkins.rest.token";
-    public static final String TEST_TOKEN_ENVIRONMENT_VARIABLE = TEST_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
+    public static final String TEST_API_TOKEN_SYSTEM_PROPERTY = "test.jenkins.rest.api.token";
+    public static final String TEST_API_TOKEN_ENVIRONMENT_VARIABLE = TEST_API_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
     private static final char[] CHARS = "abcdefghijklmnopqrstuvwxyz".toCharArray();
 
@@ -73,28 +73,30 @@ public class TestUtilities extends JenkinsUtils {
     }
 
     /**
-     * Find credentials (Basic, Bearer, or Anonymous) from system/environment.
+     * Find credentials (ApiToken, UsernamePassword, or Anonymous) from system/environment.
      *
      * @return JenkinsCredentials
      */
     public static JenkinsAuthentication inferTestAuthentication() {
 
-        // 1.) Check for "Basic" auth credentials.
         final JenkinsAuthentication.Builder inferAuth = JenkinsAuthentication.builder();
+
+        // 1.) Check for API Token as this requires no crumb hence is faster
         String authValue = JenkinsUtils
+                .retriveExternalValue(TEST_API_TOKEN_SYSTEM_PROPERTY,
+                        TEST_API_TOKEN_ENVIRONMENT_VARIABLE);
+        if (authValue != null) {
+            inferAuth.apiToken(authValue);
+            return inferAuth.build();
+        }
+
+        // 2.) Check for UsernamePassword auth credentials.
+        authValue = JenkinsUtils
                 .retriveExternalValue(TEST_CREDENTIALS_SYSTEM_PROPERTY,
                         TEST_CREDENTIALS_ENVIRONMENT_VARIABLE);
         if (authValue != null) {
             inferAuth.credentials(authValue);
-        } else {
-
-            // 2.) Check for "Bearer" auth token.
-            authValue = JenkinsUtils
-                    .retriveExternalValue(TEST_TOKEN_SYSTEM_PROPERTY,
-                            TEST_TOKEN_ENVIRONMENT_VARIABLE);
-            if (authValue != null) {
-                inferAuth.token(authValue);
-            }
+            return inferAuth.build();
         }
 
         // 3.) If neither #1 or #2 find anything "Anonymous" access is assumed.


### PR DESCRIPTION
Fixes #15 (which is a fix for https://github.com/cdancy/jenkins-rest/issues/169) but it's fixing it in this new repository.

* The crumb is needed for anonymous and for username:password
* The crumb is NOT needed for username:apiToken

I was able to confirm this behavior against a live Jenkins instance multiple times. It is also a confirmed behavior in https://github.com/jenkins-infra/jenkins.io/pull/4465 and in https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained

There are currently no explicit test included in this PR, but this code has been used successfully.

It is also not clear to me why the integration tests have not found this problem before.